### PR TITLE
fix: Fix event handler this binding in jobs.

### DIFF
--- a/src/lib/job.js
+++ b/src/lib/job.js
@@ -92,6 +92,19 @@ export default class Job extends EventEmitter {
     this.guildOnly = options.guildOnly
     this.description = options.description || ''
 
+    // NOTE: We need to bind the events here else their `this` will be `CommandoClient`.
+    for (const event of this.events) {
+      if (!isValidEvent(event)) {
+        continue
+      }
+
+      if (typeof this[event] !== 'function') {
+        console.warn(`Missing event handler for event ${event} for ${this}.`)
+      }
+
+      this[event] = this[event].bind(this)
+    }
+
     this.on('enabled', this.attachEventListeners)
     this.on('disabled', this.removeEventListeners)
 


### PR DESCRIPTION
The `this` binding was incorrect and this is the only way to fix it since if you just do `.bind(this)` in `attachEventListeners` and `removeEventListeners` then the functions won't be equal anymore and `this.client.removeListener` will fail.