### PR TITLE
fix: Incorrectly named event.

### DIFF
--- a/src/lib/job.js
+++ b/src/lib/job.js
@@ -284,7 +284,7 @@ const VALID_DISCORD_EVENTS = [
   'warn',
   'webhookUpdate',
   // Commando Events
-  'commandBlock',
+  'commandBlocked', // NOTE: Is commandBlocked in older versions and commandBlock in newer.
   'commandCancel',
   'commandError',
   'commandPrefixChange',


### PR DESCRIPTION
Always read the correct version of the docs, folks!