### PR TITLE
feat: Reduce Commando spam.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1489,9 +1489,8 @@
       }
     },
     "discord.js-commando": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/discord.js-commando/-/discord.js-commando-0.10.0.tgz",
-      "integrity": "sha1-v6mL8zEIcDdvPHoNe3Nqaj5dCg8=",
+      "version": "git+https://github.com/sustained/Commando.git#3720cc91c3391e008813819a5fd8aa546a9592a7",
+      "from": "git+https://github.com/sustained/Commando.git#0.10.0-changes",
       "requires": {
         "common-tags": "^1.0.0",
         "escape-string-regexp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vue/eslint-config-prettier": "^5.0.0",
     "babel-eslint": "^10.0.3",
     "discord.js": "^11.5.1",
-    "discord.js-commando": "^0.10.0",
+    "discord.js-commando": "git+https://github.com/sustained/Commando#0.10.0-changes",
     "dotenv": "^8.1.0",
     "eslint": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.0",

--- a/src/jobs/cleanup.js
+++ b/src/jobs/cleanup.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-unused-vars */
+import Job from '../lib/job'
+import { tryDelete } from '../utils/messages'
+
+/*
+  Commando is quite spammy in certain cases. This cleans up the spam automatically, 
+  shortly after giving the user a little while to read the error or information.
+
+    - When a command sets userPermissions, a user without permissions receives:
+        @user, The example command requires you to have the following permissions: ...
+    - When an unknown command is triggered, a user receives:
+        @user, Unknown command. Use !help to view the list of all commands.
+    - When a command errors, a user receives:
+        @user, An error occurred while running the command: Error: ...
+    - When argument parsing is cancelled, a user receives:
+        @user, Cancelled command.
+  
+  These messages can overwhelm the chat and are not particularly useful after having 
+  been read (except for errors which we should (and will) keep track of).
+*/
+export default class CleanupJob extends Job {
+  constructor(client) {
+    super(client, {
+      name: 'cleanup',
+      events: [
+        'commandBlocked',
+        'commandCancel',
+        'commandError',
+        'unknownCommand',
+      ],
+      description:
+        'Cleans up bot-spam from blocked, cancelled, errored and unknown commands.',
+      enabled: true,
+      config: {
+        removeMessagesAfter: 7500,
+      },
+    })
+  }
+
+  shouldExecute() {
+    return false
+  }
+
+  commandBlocked(msg, reason, data) {
+    if (reason === 'throttling' || reason === 'permission') {
+      this.cleanup(msg)
+    }
+  }
+
+  /*
+    NOTE: This one isn't going to work until we upgrade Commando.
+  */
+  commandCancel(cmd, reason, msg, result) {
+    this.cleanup(msg)
+  }
+
+  commandError(cmd, err, msg, args, fromPattern, result) {
+    this.cleanup(msg)
+  }
+
+  unknownCommand(msg) {
+    this.cleanup(msg)
+  }
+
+  cleanup(msg) {
+    setTimeout(async () => {
+      /**
+       * @see https://discord.js.org/#/docs/commando/v0.10.0/class/CommandMessage?scrollTo=responses
+       */
+      const responseMessages = Object.values(msg.responses)
+
+      if (!responseMessages.length) {
+        return tryDelete(msg)
+      }
+
+      for (const messages of responseMessages) {
+        for (const message of messages) {
+          await tryDelete(message)
+        }
+      }
+
+      tryDelete(msg)
+    }, this.config.removeMessagesAfter)
+  }
+}


### PR DESCRIPTION
Commando can be quite spammy at times and I'm concerned about it annoying people on the server.

The CleanupJob, when enabled, removes the bot's responses to certain messages (and the message that triggered the responses).

How do people feel about this one?

# Todo

Reduce spam when...

- [x] a command with `userPermissions` is blocked.
- [x] an unknown command is triggered.
- [x] a command errors.
- [x] argument parsing is cancelled
- [x] ~~when a user uses the help command~~
  - not necessary as a custom help command will remove this issue

**NOTE:** The unchecked item requires an upgrade to an unstable release of Commando.