### PR TITLE
enhance: Extract (+ fuzzy-search) markdown headings.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/vuejs.org"]
+	path = packages/vuejs.org
+	url = https://github.com/vuejs/vuejs.org

--- a/data/docs.hjson
+++ b/data/docs.hjson
@@ -5,7 +5,7 @@
       items: [
         {
           title: Installation
-          link: https://vuejs.org/v2/api/#silent
+          link: https://vuejs.org/v2/guide/installation.html
           description: '''
               - where to find the release notes
               - how to install from CDN, NPM or CLI

--- a/data/docs.hjson
+++ b/data/docs.hjson
@@ -5,108 +5,61 @@
       items: [
         {
           title: Installation
-          link: https://vuejs.org/v2/guide/installation.html
-          description: '''
-              - where to find the release notes
-              - how to install from CDN, NPM or CLI
-              - what the different builds are for
-          '''
+          path: guide/installation
+          aliases: [
+            install
+          ]
         }
         {
           title: Introduction
-          link: https://vuejs.org/v2/guide/index.html
+          path: guide/index
           aliases: [
-            getting started
+            intro
           ]
-          description: '''
-            - how to get started with Vue
-            - what declarative rendering is
-            - how conditionals and loops work
-            - how to handle user input
-            - how to compose with components
-          '''
         }
         {
           title: The Vue Instance
-          link: https://vuejs.org/v2/guide/instance.html
-          description: '''
-            - how to create a Vue instance
-            - how to work with data and methods
-            - about the instance lifecycle hooks
-            - view the lifecycle diagram
-          '''
+          path: guide/instance
         }
         {
           title: Template Syntax
-          link: https://vuejs.org/v2/guide/syntax.html
-          description: '''
-            - how to interpolate
-            - how to use directives
-            - about directive shorthand forms
-          '''
+          path: guide/syntax
         }
         {
           title: Computed Properties & Watchers
-          link: https://vuejs.org/v2/guide/computed.html
-          description: '''
-            - how and when to use computed properties and watchers
-          '''
+          path: guide/computed
         }
         {
           title: Class & Style Bindings
-          alises: [
+          aliases: [
             classes
+            class bindings
           ]
-          link: https://vuejs.org/v2/guide/class-and-style.html
-          description: '''
-            - how to bind HTML classes and inline styles
-          '''
+          path: guide/class-and-style
         }
         {
           title: Conditional Rendering
-          link: https://vuejs.org/v2/guide/conditional.html
-          description: '''
-            - how to conditionally render with `v-if`
-            - how to conditionally display with `v-show`
-            - the difference between `v-if` and `v-show`
-            - using `v-if` with `v-for`
-          '''
+          path: guide/conditional
         }
         {
           title: List Rendering
-          link: https://vuejs.org/v2/guide/list.html
-          description: '''
-            - how to render arrays and objects with `v-for`
-            - about array and object change detection caveats
-            - and more!
-          '''
+          path: guide/list
+          aliases: [
+            array caveats
+            object caveats
+          ]
         }
         {
           title: Event Handling
-          link: https://vuejs.org/v2/guide/events.html
-          description: '''
-            - how to listen for events, inline and via methods
-            - about event and key modifiers
-          '''
+          path: guide/events
         }
         {
           title: Form Input Bindings
-          link: https://vuejs.org/v2/guide/forms.html
-          description: '''
-            - how to use `v-model` with form inputs and components
-            - about `v-model` modifiers
-          '''
+          path: guide/forms
         }
         {
           title: Component Basics
-          link: https://vuejs.org/v2/guide/components.html
-          description: '''
-            - how to create and work with components
-            - how to pass data to child components
-            - how to listen to child component events
-            - how to distribute content with slots
-            - and more!
-          '''
+          path: guide/components
         }
       ]
     }
@@ -115,62 +68,44 @@
       items: [
         {
           title: Component Registration
-          link: https://vuejs.org/v2/guide/components-registration.html
-          description: '''
-            - about component naming
-            - the differences between global and local registration
-            - how components work with module systems (e.g. Babel)
-          '''
+          path: guide/components-registration
         }
         {
           title: Props
-          link: https://vuejs.org/v2/guide/components-props.html
-          description: '''
-            - about prop casing and prop types
-            - about one-way data flow
-            - how to validate props
-            - and more!
-          '''
+          path: guide/components-props
+          aliases: [
+            replace existing attr
+            merge existing attr
+            attr inheritance
+          ]
         }
         {
           title: Custom Events
-          link: https://vuejs.org/v2/guide/components-custom-events.html
-          description: '''
-            - how event naming works
-            - binding native events on components
-            - the `.sync` event modifier
-          '''
+          path: guide/components-custom-events
+          aliases: [
+            .sync
+          ]
         }
         {
           title: Slots
-          link: https://vuejs.org/v2/guide/components-slots.html
-          description: '''
-            - what slots are and how to use them
-            - about slot compilation scope
-            - advanced use-cases with named and scoped slots
-            - and more!
-          '''
+          path: guide/components-slots
         }
         {
           title: Dynamic & Async Components
-          link: https://vuejs.org/v2/guide/components-dynamic-async.html
+          path: guide/components-dynamic-async
           see: [
             https://vuejs.org/v2/guide/components.html
           ]
-          description: '''
-            - how to use `<keep-alive>` with dynamic components
-            - about asynchronous components
-          '''
         }
         {
           title: Handling Edge Cases
-          link: https://vuejs.org/v2/guide/components-edge-cases.html
-          description: '''
-            - how to access component instances and elements
-            - about programmatic event listeners
-            - alternative methods of defining templates
-            - and more!
-          '''
+          path: guide/components-edge-cases
+          aliases: [
+            force update
+            access root
+            access parent
+            access child
+          ]
         }
       ]
     }
@@ -179,27 +114,16 @@
       items: [
         {
           title: Enter/Leave & List Transitions
-          link: https://vuejs.org/v2/guide/transitions.html
-          description: '''
-            - how to transition single elements / components
-            - how to transition between different elements / components
-            - about list transitions
-            - and more!
-          '''
+          path: guide/transitions
           see: [
             https://vuejs.org/v2/guide/transitioning-state.html
           ]
         }
         {
           title: State Transitions
-          link: https://vuejs.org/v2/guide/transitioning-state.html
-          description: '''
-            - how to animate state with watchers
-            - about dynamic state transitions
-            - and more!
-          '''
+          path: guide/transitioning-state
           see: [
-            link: https://vuejs.org/v2/guide/transitions.html
+            https://vuejs.org/v2/guide/transitions.html
           ]
         }
       ]
@@ -209,47 +133,34 @@
       items: [
         {
           title: Mixins
-          link: https://vuejs.org/v2/guide/mixins.html
-          description: '''
-            - what mixins are and how to use them
-            - how option merging works
-            - about local versus global mixins
-          '''
+          path: guide/mixins
+          aliases: [
+            merge options
+          ]
         }
         {
           title: Custom Directives
-          link: https://vuejs.org/v2/guide/custom-directive.html
-          description: '''
-            - what directives are and how to use them
-            - about directive hook functions and arguments
-            - and more!
-          '''
+          path: guide/custom-directive
         }
         {
           title: Render Functions & JSX
-          link: https://vuejs.org/v2/guide/render-function.html
-          description: '''
-            - when render functions are a practical choice
-            - about the createElement function
-            - how to use JSX
-            - what functional components are
-            - and more!
-          '''
+          path: guide/render-function
+          aliases: [
+            jsx
+            vdom
+          ]
         }
         {
           title: Plugins
-          link: https://vuejs.org/v2/guide/plugins.html
-          description: '''
-            - how to use existing plugins
-            - how to write your own plugins
-          '''
+          path: guide/plugins
+          aliases: [
+            write plugin
+            use plugin
+          ]
         }
         {
           title: Filters
-          link: https://vuejs.org/v2/guide/filters.html
-          description: '''
-            - what filters are and how to use them
-          '''
+          path: guide/filters
         }
       ]
     }
@@ -258,47 +169,32 @@
       items: [
         {
           title: Single File Components
-          link: https://vuejs.org/v2/guide/single-file-components.html
-          description: '''
-            - what single file components are
-            - how to get started with them
-          '''
+          path: guide/single-file-components
           aliases: [
             SFC
           ]
         }
         {
           title: Unit Testing
-          link: https://vuejs.org/v2/guide/unit-testing.html
-          description: '''
-            - how to do simple assertions
-            - how to write testable components
-            - and more!
-          '''
+          path: guide/unit-testing
+          aliases: [
+            assertions
+          ]
         }
         {
           title: TypeScript Support
-          link: https://vuejs.org/v2/guide/typescript.html
-          description: '''
-            - where to find TS types for vue packages
-            - info. about recommended configurations
-            - about class-style Vue components
-            - how to augment types for plugins
-            - and more!
-          '''
+          path: guide/typescript
           aliases: [
             TS
+            vue-class-component
           ]
         }
         {
           title: Production Deployment
-          link: https://vuejs.org/v2/guide/deployment.html
-          description: '''
-            - how to activate production mode
-            - how to pre-compile templates
-            - how to extract component CSS
-            - how to track runtime errors
-          '''
+          path: guide/deployment
+          see: [
+            https://cli.vuejs.org/guide/deployment.html
+          ]
         }
       ]
     }
@@ -307,34 +203,24 @@
       items: [
         {
           title: Routing
-          link: https://vuejs.org/v2/guide/routing.html
-          description: '''
-            - what the official routing solution is
-            - how to build a simple router from scratch
-            - how to integrate a 3rd-party router
-          '''
+          path: guide/routing
           aliases: [
-            route
+            router
+            vue-router
+            vue router
           ]
         }
         {
           title: State Management
-          link: https://vuejs.org/v2/guide/state-management.html
-          description: '''
-            - about the official state management solution - Vuex
-            - how to build simple state management from scratch
-          '''
+          path: guide/state-management
           aliases: [
             vuex
+            flux
           ]
         }
         {
           title: Server-Side Rendering
-          link: https://vuejs.org/v2/guide/ssr.html
-          description: '''
-            - where to find the SSR guide
-            - info. on popular solutions like Nuxt and Quasar
-          '''
+          path: guide/ssr
           see: [
             https://ssr.vuejs.org/
           ]
@@ -344,13 +230,10 @@
         }
         {
           title: Security
-          link: https://vuejs.org/v2/guide/security.html
-          description: '''
-            - how to report security vulnerabilities
-            - what Vue does to protect you
-            - about the potential dangers
-            - and more!
-          '''
+          path: guide/security
+          aliases: [
+            injection
+          ]
         }
       ]
     }
@@ -359,13 +242,10 @@
       items: [
         {
           title: Reactivity In Depth
-          link: https://vuejs.org/v2/guide/reactivity.html
-          description: '''
-            - how changes are tracks
-            - about change detection caveats
-            - how to declare reactive properties
-            - about the async update queue
-          '''
+          path: guide/reactivity
+          aliases: [
+            change tracking
+          ]
         }
       ]
     }
@@ -374,24 +254,18 @@
       items: [
         {
           title: Migration from Vue 1.x
-          link: https://vuejs.org/v2/guide/migration.html
-          description: '''
-            - how to migrate from Vue 1.x
-          '''
+          path: guide/migration
+          extractHeadings: false
         }
         {
           title: Migration from Vue Router 0.7.x
-          link: https://vuejs.org/v2/guide/migration-vue-router.html
-          description: '''
-            - how to migrate from Vue Router 0.7.x
-          '''
+          path: guide/migration-vue-router
+          extractHeadings: false
         }
         {
           title: Migration from Vue 0.6.x to 1.0
-          link: https://vuejs.org/v2/guide/migration-vuex.html
-          description: '''
-            - how to migrate from Vue 0.6.x to 1.0
-          '''
+          path: guide/migration-vuex
+          extractHeadings: false
         }
       ]
     }
@@ -400,29 +274,23 @@
       items: [
         {
           title: Comparison with Other Frameworks
-          link: https://vuejs.org/v2/guide/comparison.html
-          description: '''
-            - how vue compares to React, AngularJS, Ember and more
-          '''
+          path: guide/comparison
         }
         {
           title: Join the Vue.js Community!
-          link: https://vuejs.org/v2/guide/join.html
-          description: '''
-            - about the resources at your disposal
-            - about how you can help the project
-          '''
+          path: guide/join
+          aliases: [
+            resources
+            support
+            ecosystem
+            contribute
+          ]
         }
         {
           title: Meet the Team
-          link: https://vuejs.org/v2/guide/team.html
-          description: '''
-            - who the active core members are
-            - about past core team members
-            - about our community partners
-          '''
+          path: guide/team
           aliases: [
-            team
+            core team
           ]
         }
       ]
@@ -432,26 +300,43 @@
       items: [
         {
           title: Style Guide
-          link: https://vuejs.org/v2/style-guide/
-          description: '''
-            - learn about the different rule categories and the rules therein
-          '''
+          path: style-guide/index
         }
         {
           title: Examples
-          link: https://vuejs.org/v2/examples/
-          description: '''
-            - find example projects which you can edit on JSFiddle
-          '''
+          path: examples/index
+          headings: [
+            Markdown Editor
+            Github Commits
+            Grid Component
+            Tree View
+            SVG Graph
+            Modal Component
+            Elastic Header
+            Wrapper Component
+            Realtime with deepstreamHub
+            Firebase + validation
+            TodoMVC
+            HackerNews Clone
+          ]
+          extractHeadings: false
         }
         {
           title: Cookbook
-          link: https://vuejs.org/v2/cookbook/
+          path: cookbook/index
+        }
+        {
+          title: Vue CLI
           description: '''
-            - find self-contained "recipes" which stand alone
-            - goes into greater detail than the guide
-            - aims to also teach JavaScript concepts
+            Vue CLI is not yet documented.
           '''
+          aliases: [
+            vue-cli
+            cli
+          ]
+          see: [
+            https://cli.vuejs.org/
+          ]
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-land-bot",
-  "version": "1.0.0",
+  "version": "0.1.0-beta-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -496,6 +496,11 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+    },
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -884,6 +889,11 @@
         "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
+    "bail": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1131,6 +1141,21 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -1228,6 +1253,11 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
+    },
+    "collapse-white-space": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2073,8 +2103,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2197,6 +2226,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "requires": {
+        "format": "^0.2.2"
+      }
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2322,6 +2359,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3303,6 +3345,20 @@
         }
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3365,6 +3421,11 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-decimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -3414,6 +3475,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-hexadecimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3433,6 +3499,11 @@
           }
         }
       }
+    },
+    "is-plain-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -3484,11 +3555,21 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-whitespace-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -4315,6 +4396,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-escapes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4699,6 +4785,19 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -5048,6 +5147,37 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
     },
+    "remark-frontmatter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
+      "integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
+      "requires": {
+        "fault": "^1.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-parse": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
+      "integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -5063,8 +5193,12 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.0",
@@ -5853,6 +5987,11 @@
         }
       }
     },
+    "state-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -6208,10 +6347,25 @@
         "punycode": "^2.1.0"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+    },
+    "trough": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
     },
     "tslib": {
       "version": "1.10.0",
@@ -6251,6 +6405,27 @@
         "source-map": "~0.6.1"
       }
     },
+    "unherit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "unified": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      }
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -6268,6 +6443,43 @@
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+      "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      }
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6374,6 +6586,39 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vfile": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+      "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+    },
+    "vfile-message": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vue-eslint-parser": {
@@ -6568,8 +6813,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,13 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-vue": "^5.2.3",
     "esm": "^3.2.25",
-    "github-api": "^3.3.0",
     "fuse.js": "^3.4.6",
+    "github-api": "^3.3.0",
     "hjson": "^3.1.2",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "remark-frontmatter": "^1.3.2",
+    "remark-parse": "^7.0.2",
+    "unified": "^8.4.2"
   },
   "devDependencies": {
     "jest": "^24.9.0",

--- a/src/commands/documentation/doc.js
+++ b/src/commands/documentation/doc.js
@@ -2,7 +2,7 @@ import { Command } from 'discord.js-commando'
 import { getDoc, findDoc, DocNotFoundError } from '../../services/docs'
 import { RichEmbed } from 'discord.js'
 import { EMPTY_MESSAGE } from '../../utils/constants'
-import { inlineCode, blockCode } from '../../utils/string'
+import { inlineCode } from '../../utils/string'
 import { cleanupInvocation, cleanupErrorResponse } from '../../utils/messages'
 import {
   DEFAULT_EMBED_COLOUR,

--- a/src/commands/documentation/doc.js
+++ b/src/commands/documentation/doc.js
@@ -123,6 +123,10 @@ module.exports = class DocumentationDocCommand extends Command {
         'Perhaps you meant one of these:',
         results.map(result => inlineCode(result.id)).join(', ')
       )
+      .addField(
+        'HINT',
+        'Use the buttons below to navigate through the matches!'
+      )
       .setAuthor(
         (msg.member ? msg.member.displayName : msg.author.username) +
           ' requested:',

--- a/src/services/docs.js
+++ b/src/services/docs.js
@@ -1,8 +1,12 @@
 import { join } from 'path'
+import { resolve } from 'url'
 import { readFileSync, existsSync } from 'fs'
 import HJSON from 'hjson'
 import Fuse from 'fuse.js'
-import { DATA_DIR } from '../utils/constants'
+import unified from 'unified'
+import remarkParse from 'remark-parse'
+import remarkFrontmatter from 'remark-frontmatter'
+import { DATA_DIR, DOCS_BASE_URL, DOCS_MARKDOWN_DIR } from '../utils/constants'
 
 const API_DATA_FILE = join(DATA_DIR, 'docs.hjson')
 
@@ -23,23 +27,15 @@ try {
 }
 
 const aliasMap = {}
-
 export const apis = {}
 
 /*
-  Flatten data and build alias map.
+  Extend item, flatten data and build alias map.
 */
 for (const category of apiData.categories) {
-  for (const item of category.items) {
-    if (!item.id) {
-      item.id = item.title
-    }
-
-    item.id = item.id.toLowerCase()
-
-    apis[item.id] = Object.assign(item, {
-      category: category.title,
-    })
+  for (let item of category.items) {
+    item = _extendItem(item, category)
+    apis[item.id] = item
 
     if (item.aliases) {
       for (const alias of item.aliases) {
@@ -106,4 +102,70 @@ export class DocNotFoundError extends Error {
     super(message)
     this.name = 'DocNotFoundError'
   }
+}
+
+/**
+ * Extract the headings from a raw markdown document.
+ * @param {string} markdown The raw markdown.
+ * @returns {Array} The headings.
+ */
+function _extractHeadings(markdown) {
+  const parsed = unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter)
+    .parse(markdown)
+    .children.filter(node => node.type === 'heading')
+
+  const headings = []
+
+  for (const node of parsed) {
+    headings.push({
+      text: node.children.map(child => child.value).join(''),
+      depth: node.depth,
+    })
+  }
+
+  return headings
+}
+
+/**
+ * Extend the doc item with extra data e.g. category, markdown headings etc.
+ * @param {object} item The doc item to extend.
+ * @param {object} category The category the doc item belongs to.
+ * @returns {object} The extended item.
+ */
+function _extendItem(item, category) {
+  if (!item.id) {
+    item.id = item.title
+  }
+  item.id = item.id.toLowerCase()
+
+  if (typeof item.extractHeadings === 'undefined' && item.path) {
+    item.extractHeadings = true
+  }
+
+  if (item.headings) {
+    item.headings = item.headings.map(heading => ({ depth: 2, text: heading }))
+  }
+
+  let headings = item.headings ? item.headings : []
+
+  if (item.extractHeadings) {
+    const markdown = readFileSync(join(DOCS_MARKDOWN_DIR, `${item.path}.md`), {
+      encoding: 'utf8',
+    })
+    headings = _extractHeadings(markdown)
+  }
+
+  if (!item.description) {
+    item.description = headings
+      .filter(heading => heading.depth === 2)
+      .map(heading => `- ${heading.text}`)
+      .join('\n')
+  }
+
+  item.link = resolve(DOCS_BASE_URL, `${item.path}.html`)
+  item.category = category.title
+
+  return item
 }

--- a/src/services/docs.js
+++ b/src/services/docs.js
@@ -55,12 +55,16 @@ for (const category of apiData.categories) {
 const fuse = new Fuse(Object.values(apis), {
   shouldSort: true,
   includeScore: true,
-  threshold: 0.35, // TODO: Experiment more but this seems fairly good for now.
+  threshold: 0.4,
   location: 0,
-  distance: 100,
+  distance: 42,
   maxPatternLength: 32,
-  minMatchCharLength: 1,
-  keys: ['title', 'aliases'],
+  minMatchCharLength: 3,
+  keys: [
+    { name: 'title', weight: 1.0 },
+    { name: 'aliases', weight: 1.0 },
+    { name: 'headings.text', weight: 0.75 },
+  ],
 })
 
 /**

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -44,6 +44,10 @@ const EMPTY_MESSAGE = '\u200b'
 */
 
 const DATA_DIR = resolve(__dirname, '../../../data')
+const DOCS_MARKDOWN_DIR = resolve(
+  __dirname,
+  '../../../packages/vuejs.org/src/v2/'
+)
 
 const AUTOMATICALLY_DELETE_ERRORS = true
 const AUTOMATICALLY_DELETE_INVOCATIONS = true
@@ -89,6 +93,7 @@ export {
   BOT_DEVELOPER_IDS,
   EMPTY_MESSAGE,
   DATA_DIR,
+  DOCS_MARKDOWN_DIR,
   AUTOMATICALLY_DELETE_ERRORS,
   AUTOMATICALLY_DELETE_INVOCATIONS,
   DELETE_ERRORS_AFTER_MS,

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -40,15 +40,20 @@ const MODERATOR_ROLE_IDS = Object.freeze([ROLES.CORE_TEAM, ROLES.MODERATORS])
 const EMPTY_MESSAGE = '\u200b'
 
 /*
-  Various paths.
+  Various paths and URLs.
 */
-
 const DATA_DIR = resolve(__dirname, '../../../data')
 const DOCS_MARKDOWN_DIR = resolve(
   __dirname,
   '../../../packages/vuejs.org/src/v2/'
 )
+const DOCS_BASE_URL = 'https://vuejs.org/v2/'
+const CDN_BASE_URL =
+  'https://raw.githubusercontent.com/Elfayer/vue-land-bot/master/'
 
+/*
+  Constants relating to the messages util (should these be moved?).
+*/
 const AUTOMATICALLY_DELETE_ERRORS = true
 const AUTOMATICALLY_DELETE_INVOCATIONS = true
 const DELETE_ERRORS_AFTER_MS = 30000
@@ -78,14 +83,10 @@ const EMOJIS = {
   },
 }
 
-const CDN_BASE_URL =
-  'https://raw.githubusercontent.com/Elfayer/vue-land-bot/master/'
-
 export {
   USERS,
   ROLES,
   EMOJIS,
-  CDN_BASE_URL,
   OWNER_IDS,
   PROTECTED_USER_IDS,
   PROTECTED_ROLE_IDS,
@@ -94,6 +95,8 @@ export {
   EMPTY_MESSAGE,
   DATA_DIR,
   DOCS_MARKDOWN_DIR,
+  CDN_BASE_URL,
+  DOCS_BASE_URL,
   AUTOMATICALLY_DELETE_ERRORS,
   AUTOMATICALLY_DELETE_INVOCATIONS,
   DELETE_ERRORS_AFTER_MS,


### PR DESCRIPTION
Ignore the branch name, originally this was a full-text search through the guide markdown... which proved problematic.

- [x] Extract the headings and make them searchable
  - [x] Added option to not extract headings because some pages really skew the results (e.g. migration).
  - [x] Description is built dynamically based on headings, unless already present.
- [x] Added some extra aliases, for cases the fuzzy searcher still misses.